### PR TITLE
feat(recommendations): end-to-end dynamic filtering with level fallback

### DIFF
--- a/src/app/api/recommend-routines-by-answer/route.ts
+++ b/src/app/api/recommend-routines-by-answer/route.ts
@@ -1,8 +1,7 @@
-// app/api/base-routines/route.ts
+// app/api/recommended-routines/route.ts
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 
-// 1️⃣ Define y exporta el tipo Routine
 export type Routine = {
   id: string;
   slug: string;
@@ -23,10 +22,35 @@ export type Routine = {
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SERVICE_ROLE_KEY!
+  process.env.SERVICE_ROLE_KEY! // ⬅️  service-role para usar el RPC sin RLS
 );
 
-export async function GET() {
+export async function GET(req: Request) {
+  /** 1️⃣ Toma `answer_id` como query param ?answer_id=... */
+  const { searchParams } = new URL(req.url);
+  const answerId = searchParams.get("answer_id");
+  if (!answerId)
+    return NextResponse.json(
+      { error: "Missing query param: answer_id" },
+      { status: 400 }
+    );
+
+  /** 2️⃣ Llama al RPC que ya creaste */
+  const { data: recs, error: rpcError } = await supabase.rpc(
+    "recommend_routines_by_answer",
+    { p_answer_id: answerId }
+  );
+
+  if (rpcError)
+    return NextResponse.json({ error: rpcError.message }, { status: 500 });
+
+  // Si no hay recomendación, responde lista vacía
+  if (!recs || recs.length === 0) return NextResponse.json([]);
+
+  /** 3️⃣ Extrae los IDs recomendados */
+  const routineIds = recs.map((r: any) => r.routine_id);
+
+  /** 4️⃣ Trae los detalles con ejercicios sólo para esos IDs */
   const { data, error } = await supabase
     .from("base_routines")
     .select(
@@ -50,13 +74,13 @@ export async function GET() {
       )
     `
     )
-    .order("slug");
+    .in("id", routineIds); // ⬅️  filtro por los recomendados
 
-  if (error) {
+  if (error)
     return NextResponse.json({ error: error.message }, { status: 500 });
-  }
 
-  const routines = data!.map((r: any) => ({
+  /** 5️⃣ Misma transformación que usabas antes */
+  const routines: Routine[] = data!.map((r: any) => ({
     id: r.id,
     slug: r.slug,
     name: r.name,

--- a/src/app/questionnaire/components/QuestionnarieForm.tsx
+++ b/src/app/questionnaire/components/QuestionnarieForm.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";  
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -48,14 +48,6 @@ export default function QuestionnaireForm() {
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-
-  useEffect(() => {
-    if (success) {
-      const timer = setTimeout(() => router.push("/dashboard"), 2500);
-      return () => clearTimeout(timer);
-    }
-  }, [success, router]);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -85,24 +77,22 @@ export default function QuestionnaireForm() {
   }
 
   async function submitAnswers(payload: any) {
-    const response = await fetch("/api/user-answers", {
+    const res = await fetch("/api/user-answers", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.error || "Error al guardar las respuestas");
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error || "Error al guardar las respuestas");
     }
-
-    return response.json();
+    return res.json(); // ← { id: "uuid-nuevo" }
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    setSuccess(false);
     setLoading(true);
 
     if (!user?.id) {
@@ -141,12 +131,13 @@ export default function QuestionnaireForm() {
     }
 
     try {
-      await submitAnswers({
+      const { id } = await submitAnswers({
         ...formData,
         user_id: user.id,
         availability: availabilityNum,
       });
-      setSuccess(true);
+      router.push(`/routine?answer_id=${id}`);
+
       setFormData({
         training_experience: "",
         availability: "",
@@ -231,7 +222,7 @@ export default function QuestionnaireForm() {
                     type="checkbox"
                     name="injuries"
                     value={inj.value}
-                    checked={formData.injuries.includes(inj.value)}
+                    checked={formData.injuries.includes(inj.value as string)}
                     onChange={handleChange}
                   />
                   <span>{inj.label}</span>
@@ -351,12 +342,6 @@ export default function QuestionnaireForm() {
           {/* Mensajes */}
           {error && (
             <p className="text-red-600 font-semibold text-center">{error}</p>
-          )}
-
-          {success && (
-            <p className="text-green-600 font-semibold text-center">
-              Respuestas guardadas correctamente. Redirigiendo...
-            </p>
           )}
 
           {/* Botón */}

--- a/src/app/routine/components/RoutineList.tsx
+++ b/src/app/routine/components/RoutineList.tsx
@@ -2,27 +2,37 @@
 
 import useSWR from "swr";
 import { useState } from "react";
-import type { Routine } from "@/app/api/base-routines/route";
-import LoadingSpinner from "../../../components/common/LoadingSpinner";
+import type { Routine } from "@/app/api/recommend-routines-by-answer/route";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 import RoutineRunner from "@/app/routine/components/RoutineRunner";
 
+/* Utilidad genérica para fetch + manejo de errores */
 const fetcher = (url: string) =>
   fetch(url).then((res) => {
     if (!res.ok) throw new Error(res.statusText);
     return res.json();
   });
 
-export function RoutineList() {
-  const { data, error, isLoading } = useSWR<Routine[]>(
-    "/api/base-routines",
+/* Props: el UUID de la fila en user_answers
+   Pásalo como null/undefined mientras aún no lo tengas */
+interface RoutineListProps {
+  answerId: string | null;
+}
+
+export default function RoutineList({ answerId }: RoutineListProps) {
+  /* Llama al endpoint solo cuando answerId ya existe */
+  const { data, error } = useSWR<Routine[]>(
+    answerId ? `/api/recommend-routines-by-answer?answer_id=${answerId}` : null,
     fetcher
   );
+
   const [selectedRoutine, setSelectedRoutine] = useState<Routine | null>(null);
 
+  /* Estado de error / carga */
   if (error) return <p className="text-red-500">Error cargando rutinas</p>;
   if (!data) return <LoadingSpinner />;
 
-  // Si ya elegí una rutina, muestro el runner
+  /* Vista runner si ya eligieron una rutina */
   if (selectedRoutine) {
     return (
       <RoutineRunner
@@ -32,17 +42,17 @@ export function RoutineList() {
     );
   }
 
-  // Si no, muestro el listado con botón de “Empezar rutina”
+  /* Vista listado de rutinas */
   return (
     <div className="grid gap-8">
       {data.map((routine) => (
         <section key={routine.id} className="p-6 border rounded-lg shadow">
           <h2 className="text-2xl font-bold mb-2">{routine.name}</h2>
+
           {routine.description && (
             <p className="text-gray-600 mb-4">{routine.description}</p>
           )}
 
-          {/* Card resumen: nombre + target */}
           <div className="flex justify-between items-center">
             <div>
               <p className="font-medium">
@@ -51,10 +61,11 @@ export function RoutineList() {
               <p className="text-sm text-gray-500">
                 Músculos:{" "}
                 {Array.from(
-                  new Set(routine.exercises.map((e) => e.target))
+                  new Set(routine.exercises.map((e: any) => e.target))
                 ).join(", ")}
               </p>
             </div>
+
             <button
               onClick={() => setSelectedRoutine(routine)}
               className="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600"

--- a/src/app/routine/components/RoutineRunner.tsx
+++ b/src/app/routine/components/RoutineRunner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { Routine } from "@/app/api/base-routines/route";
+import type { Routine } from "@/app/api/recommend-routines-by-answer/route";
 import { ArrowLeft } from "lucide-react";
 
 // The types for the component's state and props remain the same

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -1,13 +1,44 @@
+// app/(protected)/routine/page.tsx   ← o la ruta donde tengas la página
 "use client";
-import { RoutineList } from "@/app/routine/components/RoutineList";
-function ExercisesPage() {
-  return (
-    <>
-      <div className="max-w-7xl mx-auto p-8">
-        <RoutineList />
+
+import { useSearchParams } from "next/navigation";
+import RoutineList from "@/app/routine/components/RoutineList";
+import useSWR from "swr";
+
+const fetcher = (url: string) =>
+  fetch(url).then((res) => {
+    if (!res.ok) throw new Error(res.statusText);
+    return res.json();
+  });
+
+export default function RoutinePage() {
+  const searchParams = useSearchParams();
+  const answerId = searchParams.get("answer_id"); // ← "7cacba81-…" o null
+  const { data, error } = useSWR(
+    answerId ? `/api/recommend-routines-by-answer?answer_id=${answerId}` : null,
+    fetcher
+  );
+
+  if (!answerId) {
+    return (
+      <div className="p-8 text-gray-600 max-w-xl mx-auto">
+        Falta el parámetro <code>answer_id</code>. Completa primero el
+        cuestionario de preferencias.
       </div>
-    </>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="p-8 text-gray-600 max-w-xl mx-auto">
+        No se encontraron respuestas para el ID proporcionado.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto p-8">
+      <RoutineList answerId={answerId} />
+    </div>
   );
 }
-
-export default ExercisesPage;

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -4,7 +4,7 @@ function LoadingSpinner() {
   return (
     // Outer container, styled to be a centered overlay with a blurred background.
     // Takes full screen height and ensures a minimum height of 200px.
-    <div className="flex flex-col h-screen items-center justify-center min-h-[200px] p-6 rounded-lg bg-white/10 backdrop-blur-sm border border-white/20 shadow-lg transition-all duration-300">
+    <div className="w-full h-full flex flex-col items-center justify-center p-6 rounded-lg bg-white/10 backdrop-blur-sm border border-white/20 shadow-lg transition-all duration-300">
       {/* The spinning element, styled with borders to create the spinner effect and an animation. */}
       <div className="w-12 h-12 border-4 border-t-purple-400 border-white rounded-full animate-spin mb-4"></div>
       {/* Text message displayed below the spinner. */}


### PR DESCRIPTION
* **db**
  * add `injury_areas` lookup table (injury → forbidden_body_parts)
  * create `routine_summary` materialized view with GIN indexes on
    `equipments` and `body_parts`
  * add `recommend_routines` SQL fn
    * filters by goal, level, equipment, injuries
    * allows body-weight only when `equipment_access = false`
    * fixes no-injury bug via `COALESCE(..., ARRAY[]::text[])`
  * add `recommend_routines_by_answer` PL/pgSQL wrapper
    * converts JSON injuries → `text[]`
    * automatic level fallback (athlete → advanced → intermediate → beginner)
* **api**
  * `/api/user-answers`  
    * switch to `createClient` with `SERVICE_ROLE_KEY`
    * return `{ id }` instead of full row
  * `/api/recommended-routines`  
    * consume RPC using `answer_id` query param
    * hydrate routines with exercises ordered by `sort_order`
* **frontend**
  * `QuestionnaireForm` redirects to `/routine?answer_id=<uuid>` after save
  * new `/routine` page grabs `answer_id` from URL and renders `RoutineList`
  * `RoutineList`
    * lazy-fetches `/api/recommended-routines?answer_id=…`
    * shows spinner, empty-state message, or `RoutineRunner`
* **fix**: no routines returned when user had `"none"` injuries
* **docs**: list existing goal/level combos for seed guidance

BREAKING CHANGE: clients must now request recommended routines through
`/api/recommended-routines?answer_id=`; direct consumption of
`/base_routines` is deprecated.